### PR TITLE
RFC: Add instance allocator support to Wasmtime.

### DIFF
--- a/accepted/wasmtime-instance-allocator.md
+++ b/accepted/wasmtime-instance-allocator.md
@@ -282,7 +282,7 @@ pub struct InstanceLimits {
     /// Any value above 4 GiB will start eliding bounds checks provided the `offset` of the memory access is
     /// less than (`address_space_size` - 4 GiB).  A value of 8 GiB will completely elide *all* bounds
     /// checks; consequently, 8 GiB will be the maximum supported value. The default of 6 GiB reserves
-    /// less host address space for each instance, but a memory access with an offet above 2 GiB will incur
+    /// less host address space for each instance, but a memory access with an offset above 2 GiB will incur
     /// runtime bounds checks.
     ///
     /// On 32-bit platforms, the default for this value will be 10 MiB. A 32-bit host has very limited address

--- a/accepted/wasmtime-instance-allocator.md
+++ b/accepted/wasmtime-instance-allocator.md
@@ -175,62 +175,62 @@ For backwards compatibility, a `RuntimeMemoryCreator` can be used to control how
  
 ```rust
 /// Represents the limits of a pooling instance allocator.
-#[Copy, Clone]
+#[derive(Copy, Clone)]
 pub struct PoolingLimits {
-   /// The maximum number of instances supported by the allocator (default 1000).
-   pub instances: usize;
- 
-   /// The maximum number of memories supported by the allocator (default 1000).
-   ///
-   /// # Notes
-   ///
-   /// Instantiating a module with `M` number of memories will count `M` times towards this limit.
-   pub memories: usize;
- 
-   /// The maximum number of tables supported by the allocator (default 1000).
-   ///
-   /// # Notes
-   ///
-   /// Instantiating a module with `T` number of tables will count `T` times towards this limit.
-   pub tables: usize;
+    /// The maximum number of instances supported by the allocator (default 1000).
+    pub instances: usize,
 
-   /// The maximum number of function types for an instance (default is 100).
-   pub instance_function_types: usize;
- 
-   /// The maximum number of imported functions for an instance (default is 1000).
-   pub instance_imported_functions: usize;
- 
-   /// The maximum number of imported tables for an instance (default is 0).
-   pub instance_imported_tables: usize;
- 
-   /// The maximum number of imported memories for an instance (default is 0).
-   pub instance_imported_memories: usize;
- 
-   /// The maximum number of imported globals for an instance (default is 0).
-   pub instance_imported_globals: usize;
- 
-   /// The maximum number of defined functions for an instance (default is 10000).
-   pub instance_functions: usize;
- 
-   /// The maximum number of defined tables for an instance (default is 1).
-   pub instance_tables: usize;
- 
-   /// The maximum number of defined memories for an instance (default is 1).
-   pub instance_memories: usize;
- 
-   /// The maximum number of defined globals for an instance (default is 10).
-   pub instance_globals: usize;
+    /// The maximum number of memories supported by the allocator (default 1000).
+    ///
+    /// # Notes
+    ///
+    /// Instantiating a module with `M` number of memories will count `M` times towards this limit.
+    pub memories: usize,
 
-   /// The maximum number of table elements for an instance (default is 10000).
-   pub instance_table_elements: usize;
- 
-   /// The maximum size of an instance's memory in bytes (default is 1 MiB).
-   ///
-   /// A memory's maximum will be `min(memory_size, memory.maximum)`.
-   ///
-   /// The total address space reserved for an instance's memory will depend on this
-   /// value and `Tunable::static_memory_offset_guard_size`.
-   pub instance_memory_size: usize;
+    /// The maximum number of tables supported by the allocator (default 1000).
+    ///
+    /// # Notes
+    ///
+    /// Instantiating a module with `T` number of tables will count `T` times towards this limit.
+    pub tables: usize,
+
+    /// The maximum number of function types for an instance (default is 100).
+    pub instance_function_types: usize,
+
+    /// The maximum number of imported functions for an instance (default is 1000).
+    pub instance_imported_functions: usize,
+
+    /// The maximum number of imported tables for an instance (default is 0).
+    pub instance_imported_tables: usize,
+
+    /// The maximum number of imported memories for an instance (default is 0).
+    pub instance_imported_memories: usize,
+
+    /// The maximum number of imported globals for an instance (default is 0).
+    pub instance_imported_globals: usize,
+
+    /// The maximum number of defined functions for an instance (default is 10000).
+    pub instance_functions: usize,
+
+    /// The maximum number of defined tables for an instance (default is 1).
+    pub instance_tables: usize,
+
+    /// The maximum number of defined memories for an instance (default is 1).
+    pub instance_memories: usize,
+
+    /// The maximum number of defined globals for an instance (default is 10).
+    pub instance_globals: usize,
+
+    /// The maximum number of table elements for an instance (default is 10000).
+    pub instance_table_elements: usize,
+
+    /// The maximum size of an instance's memory in bytes (default is 1 MiB).
+    ///
+    /// A memory's maximum will be `min(memory_size, memory.maximum)`.
+    ///
+    /// The total address space reserved for an instance's memory will depend on this
+    /// value and `Tunable::static_memory_offset_guard_size`.
+    pub instance_memory_size: usize,
 }
 
 impl Default for PoolingLimits { ... }
@@ -260,7 +260,7 @@ This is similar to Lucet's `AllocStrategy` for regions.
 ### The `PoolingInstanceAllocator` struct
 
 ```rust
-// Represents a pooling instance allocator.
+/// Represents a pooling instance allocator.
 pub struct PoolingInstanceAllocator { ... }
 
 impl PoolingInstanceAllocator {

--- a/accepted/wasmtime-instance-allocator.md
+++ b/accepted/wasmtime-instance-allocator.md
@@ -308,11 +308,13 @@ This feature will forward to the runtime's `userfault` feature to enable userfau
 // Represents the module instance allocation strategy to use.
 #[derive(Clone)]
 pub enum InstanceAllocationStrategy {
-    /// The default Wasmtime module instance allocation strategy.
+    /// The on-demand instance allocation strategy.
     ///
     /// Resources related to a module instance are allocated at instantiation time and
     /// immediately deallocated when the `Store` referencing the instance is dropped.
-    Default,
+    ///
+    /// This is the default allocation strategy for Wasmtime.
+    OnDemand,
     /// The pooling instance allocation strategy.
     ///
     /// A pool of resources is created in advance and module instantiation reuses resources
@@ -325,6 +327,8 @@ pub enum InstanceAllocationStrategy {
         limits: PoolingLimits,
     },
 }
+
+impl Default for InstanceAllocationStrategy { ... }
 ```
 
 ### The `Config` struct


### PR DESCRIPTION
[Rendered RFC](https://github.com/peterhuene/rfcs/blob/instance-pools/accepted/wasmtime-instance-allocator.md)

This RFC proposes adding an "instance allocator" abstraction to Wasmtime to
allow for alternative instance resource allocation strategies.

One such strategy will be a "pooling instance allocator" that can quickly
allocate instances, memories, and tables from the host address space that has
been reserved in advance.

This RFC is inspired by a Lucet performance feature called "regions".