### PR TITLE
fixed link for spec CPU2017 paper

### DIFF
--- a/accepted/benchmark-suite.md
+++ b/accepted/benchmark-suite.md
@@ -729,7 +729,7 @@ Lucet at all eventually.
 [stabilizer]: https://people.cs.umass.edu/~emery/pubs/stabilizer-asplos13.pdf
 [spec-cpu-search]: https://www.spec.org/cpuv8/
 [warmup]: https://arxiv.org/pdf/1602.00602.pdf
-[spec-characterization]: https://uweb.engr.arizona.edu/~tosiron/papers/2018/SPEC2017_ISPASS18.pdf
+[spec-characterization]: https://tosiron.com/papers/2018/SPEC2017_ISPASS18.pdf
 
 1. <span id="ref-1"/> [*Wake Up and Smell the Coffee: Evaluation Methodology for
    the 21st Century* by Blackburn et al.][dacapo]


### PR DESCRIPTION
The link to the paper _A Workload Characterization of the SPEC CPU2017 Benchmark Suite_  does not go to the paper anymore, but goes to one of the author's (Tosiron Adegbija) [website](https://tosiron.com/). I changed the link to a new valid link which is from the same author's website and contains the paper.