### PR TITLE
Update vulnerability-response-runbook.md

### DIFF
--- a/accepted/vulnerability-response-runbook.md
+++ b/accepted/vulnerability-response-runbook.md
@@ -2,6 +2,7 @@
 This document describes a series of steps to be followed by the Bytecode Alliance team when responding to a vulnerability that is discovered or reported privately.
 
 This document does not cover cases where vulnerabilities are publicly disclosed without coordination. Or cases where unpatched vulnerabilities are under active exploitation. In those cases, contact security@bytecodealliance.org.
+
 ## Select an Incident Manager
 
 Pick an individual who will track that the entire process in this document is followed.
@@ -11,7 +12,7 @@ someone else.
 
 ## Identifying the Vulnerability
 
-Figure out what bytecode alliance repository it lives in.
+Figure out what Bytecode Alliance repository it lives in.
 
 The vulnerability probably lives in one single repository in the Bytecode
 Alliance ecosystem. If fixing it requires coordinated work across two
@@ -33,8 +34,13 @@ You can leave the Patched versions blank in the draft to start.
 
 ### Determine Severity
 
-We follow the Severity levels defined in the [OpenSSL Security
-Policy](https://www.openssl.org/policies/secpolicy.html).
+We report severity according to the Qualitative Severity Rating Scale defined in
+the [CVSS v3 specification]. The GitHub Security Advisory product provides a tool
+for the incident manager to select the CVSS v3 Base Metrics, and sum this to a
+score on the Qualitative Severity Rating Scale.
+
+[CVSS v3 Specification]: https://www.first.org/cvss/v3.0/specification-document#Qualitative-Severity-Rating-Scale).
+
 
 ### Draft a Description
 
@@ -73,7 +79,7 @@ In the private fork repository, create a single PR which will track the patch
 to resolve the vulnerability. This patch is automatically merged into the
 public repository's default branch when the disclosure is made public.
 
-Cloud-based CI (github actions or otherwise) will not run on the security
+Cloud-based CI (GitHub Actions or otherwise) will not run on the security
 advisory fork. Collaborators are responsible for running CI locally before
 pushing to the PR branch.
 
@@ -81,18 +87,24 @@ Use the PR review features to indicate approval for the patch.
 
 ### Releases as part of the patch
 
-Wasmtime has committed that security issues will be applied to the current
-version of Wasmtime, and released as patch releases: see [Wasmtime 1.0
-RFC](https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-one-dot-oh.md#backports---security-fixes)
+Wasmtime has committed that security issues will be applied to the current major
+version of Wasmtime, the previous major version, and the previous two LTS releases
+(i.e. those whose major version is divisible by 12). See the [Wasmtime LTS RFC]
+for more details.
 
-Other projects without an existing policy should do the same, unless they have
-a very good reason for issuing backports.
+[Wasmtime LTS RFC]: https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-lts.md
+
+Other projects without an existing policy should, at very least, provide a patch
+release of the latest released version, and consider other backports on a
+case-by-case basis.
 
 The patch PR should increment any version numbers required to make the patch
 release. The merged PR should be immediately publishable to package registries
 when the disclosure is made public. Create a merge commit and run your package
 publishing tools in dry-run mode to verify this ahead-of-time as much as
-possible.
+possible. As of this writing, its not possible to use GitHub Actions to run
+CI checks on the private forks created by GitHub Security Advisories for
+private collaboration on remediations.
 
 ## Advanced disclosure to stakeholders
 
@@ -134,9 +146,9 @@ Additionally, an advisory will be made available on <date> at approximately
 <time> at https://github.com/advisories.
 
 The highest severity issue fixed in this release is <severity>, based on the
-classification scheme defined in the OpenSSL Security Policy.
+classification scheme defined by CVSS v3.
 
-<non-affected projects> Bytecode Alliance projects are unaffected.
+Other Bytecode Alliance projects are unaffected.
 ```
 
 
@@ -151,8 +163,8 @@ who introduced or contributed to the vulnerability.
 Security Advisories may credit individuals who contributed to discovering and
 remediating the vulnerability. Use the credit feature of the GitHub Security
 Advisory to do so. This feature requires individuals to consent to being
-credited through their GitHub account. The incident manager can decide how to accommodate creditees
-who do not wish to use the GitHub mechanism.
+credited through their GitHub account. The incident manager can decide how
+to accommodate creditees who do not wish to use the GitHub mechanism.
 
 ### Template
 

--- a/accepted/vulnerability-response-runbook.md
+++ b/accepted/vulnerability-response-runbook.md
@@ -90,9 +90,10 @@ Use the PR review features to indicate approval for the patch.
 Wasmtime has committed that security issues will be applied to the current major
 version of Wasmtime, the previous major version, and the previous two LTS releases
 (i.e. those whose major version is divisible by 12). See the [Wasmtime LTS RFC]
-for more details.
+for more details and [release process] docs for the current set of supported releases.
 
 [Wasmtime LTS RFC]: https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-lts.md
+[release process]: https://docs.wasmtime.dev/stability-release.html#release-process
 
 Other projects without an existing policy should, at very least, provide a patch
 release of the latest released version, and consider other backports on a


### PR DESCRIPTION
Updates to the vulnerability response runbook:
* use CVSS instead of OpenSSL to determine severity
* wasmtime has a substantially different security backport policy
* minor capitalization and formatting fixes